### PR TITLE
Incrementing internal row counter when using fetchRow

### DIFF
--- a/lib/ResultSet.php
+++ b/lib/ResultSet.php
@@ -76,7 +76,18 @@ class ResultSet {
 			return new Success(null);
 		} else {
 			$deferred = new Deferred;
-			$this->result->deferreds[ResultProxy::SINGLE_ROW_FETCH][] = [$deferred, null, $cb];
+
+            //we need to increment the internal counter, else the next time
+            //genericFetch is called it'll simply return the row we fetch here
+            //instead of fetching a new row
+            //since callback order on promises isn't defined, we can't do this
+            //via when()
+            $incRow = function ($row) use ($cb) {
+                $this->result->userFetched++;
+                return $cb && $row ? $cb($row) : $row;
+            };
+
+			$this->result->deferreds[ResultProxy::SINGLE_ROW_FETCH][] = [$deferred, null, $incRow];
 			return $deferred->promise();
 		}
 	}

--- a/test/Mysql/ConnectionTest.php
+++ b/test/Mysql/ConnectionTest.php
@@ -39,6 +39,26 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase {
 		});
 	}
 
+    function testQueryFetchRow() {
+		(new NativeReactor)->run(function($reactor) {
+			$db = new Connection("host=".DB_HOST.";user=".DB_USER.";pass=".DB_PASS.";db=connectiontest", null, $reactor);
+			$db->connect();
+
+            $db->query('DROP TABLE tmp');
+            $db->query('CREATE TABLE tmp (a int)');
+            $db->query('INSERT INTO tmp VALUES (1), (2), (3)');
+
+            $resultset = (yield $db->query('SELECT a FROM tmp'));
+
+            $got = [];
+
+            while ($row = (yield $resultset->fetchRow()))
+                $got[] = $row;
+
+            $this->assertEquals($got, [[1], [2], [3]]);
+        });
+    }
+
 	function testMultiStmt() {
 		(new NativeReactor)->run(function($reactor) {
 			$db = new Connection("host=".DB_HOST.";user=".DB_USER.";pass=".DB_PASS.";db=connectiontest", null, $reactor);


### PR DESCRIPTION
I've fixed a bug where ResultSet::genericFetch wasn't updating result->userFetched upon fetching a new row. 

This would manifest itself as each newly fetched row being returned from fetchRow twice; once as the result from fetching the row, and then again on the second call since $this->result->userFetched < $this->result->fetchedRows.

I've also added a corresponding test case to ConnectionTest.