### PR TITLE
Updated samples to return only Promises

### DIFF
--- a/examples/003_generic_with_yield.php
+++ b/examples/003_generic_with_yield.php
@@ -15,7 +15,7 @@ require './example_bootstrap.php';
 	}
 
 	/* wait until everything is inserted (in case where we wouldn't have to wait, we also could just  */
-	yield $promises;
+	yield \Amp\all($promises);
 
 	print "Insertion successful (if it wasn't, an exception would have been thrown by now)\n";
 

--- a/examples/004_multi_rows.php
+++ b/examples/004_multi_rows.php
@@ -7,7 +7,7 @@ require 'support/generic_table.php';
 	$db = new \Amp\Mysql\Pool("host=".DB_HOST.";user=".DB_USER.";pass=".DB_PASS.";db=".DB_NAME);
 
 	/* create same table than in 003_generic_with_yield.php */
-	yield genTable($db);
+	yield \Amp\resolve(genTable($db));
 
 	/* yeah, we need a lot of yields and assigns here... With PHP 7 we finally can drop a lot of stupid parenthesis! */
 	$query = (yield $db->query("SELECT a * b FROM tmp"));
@@ -18,7 +18,9 @@ require 'support/generic_table.php';
 	/* or, maybe, wait until they're all fetched (because you anyway only can continue after having full resultset */
 	$query = (yield $db->query("SELECT a * b FROM tmp"));
 	$objs = (yield $query->fetchObjects());
-	var_dump($objs); // outputs all the rows as objects of the resultset returned by SELECT a * b FROM tmp
+	//var_dump($objs); // outputs all the rows as objects of the resultset returned by SELECT a * b FROM tmp
+
+    yield $db->query("DROP TABLE tmp");
 
 	$db->close();
 });

--- a/examples/005_multi_stmts.php
+++ b/examples/005_multi_stmts.php
@@ -7,7 +7,7 @@ require 'support/generic_table.php';
 	$db = new \Amp\Mysql\Pool("host=".DB_HOST.";user=".DB_USER.";pass=".DB_PASS.";db=".DB_NAME);
 
 	/* create same table than in 003_generic_with_yield.php */
-	yield genTable($db);
+	yield \Amp\resolve(genTable($db));
 
 	/* multi statements are enabled by default, but generally stored procedures also might return multiple resultsets anyway */
 	$promise = $db->query("SELECT a + b FROM tmp; SELECT a - b FROM tmp;");

--- a/examples/support/generic_table.php
+++ b/examples/support/generic_table.php
@@ -1,11 +1,11 @@
 <?php
 
 /* Create table and fill in a few rows for examples; for comments see 003_generic_with_yield.php */
-function genTable(\Mysql\Pool $db) {
+function genTable(\Amp\Mysql\Pool $db) {
 	yield $db->query("CREATE TABLE tmp SELECT 1 AS a, 2 AS b");
 	$promises = [];
 	foreach (range(1, 5) as $num) {
 		$promises[] = $db->query("INSERT INTO tmp (a, b) VALUES ($num, $num * 2)");
 	}
-	yield $promises;
+	yield \Amp\all($promises);
 }


### PR DESCRIPTION
Just minor fixes to the examples so they work with the latest version of amp. The examples were returning non-Promise values in certain spots, which is no longer allowed.