### PR TITLE
Fix connection pool recovery

### DIFF
--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -40,7 +40,7 @@ class Connection {
 		$restore = static function($init) use ($hash, $config) {
 			$cb = $config->restore;
 			if (isset($cb)) {
-				$cb($hash, $init);
+				return $cb($hash, $init);
 			}
 		};
 		$this->processor = new Processor($ready, $busy, $restore);

--- a/lib/Stmt.php
+++ b/lib/Stmt.php
@@ -39,7 +39,7 @@ class Stmt {
 		}
 		$restore = $this->conn->restore;
 		if (isset($restore)) {
-			$restore(true)->prepare($this->query)->when(function($error, $stmt) {
+			$restore(false)->prepare($this->query)->when(function($error, $stmt) {
 				if ($error) {
 					while (list(, $args) = $this->virtualConn->getCall()) {
 						end($args)->fail($error);

--- a/lib/Stmt.php
+++ b/lib/Stmt.php
@@ -39,7 +39,7 @@ class Stmt {
 		}
 		$restore = $this->conn->restore;
 		if (isset($restore)) {
-			$restore()->prepare($this->query)->when(function($error, $stmt) {
+			$restore(true)->prepare($this->query)->when(function($error, $stmt) {
 				if ($error) {
 					while (list(, $args) = $this->virtualConn->getCall()) {
 						end($args)->fail($error);
@@ -55,7 +55,7 @@ class Stmt {
 							$args[0] = $this->stmtId;
 						}
 						if ($method == "execute") {
-							$args[1] = &$this->result->params;
+							$args[2] = &$this->result->params;
 						}
 						call_user_func_array([$this->conn(), $method], $args)->when(function($error, $result) use ($deferred) {
 							if ($error) {


### PR DESCRIPTION
I've managed to fix these 2 little issues in the call graph related to connection pool recovery, which is good enough for 90% use cases.

But I still could not handle the situation when prepared statements were prepared before the database was restarted.

Scenario:

- Prepare some statement and keep it in memory
- Database is restarted
- Reuse the prepared statement previously prepared

Error:

```
Amp\\Mysql\\QueryException: MySQL error (1243): #HY000 Unknown prepared statement handler (1) given to mysqld_stmt_execute
Current query was SELECT
    [...] omitted [..]
 in /vendor/amphp/mysql/lib/Processor.php:393
 Stack trace:
 #0 /vendor/amphp/mysql/lib/Processor.php(1097): Amp\\Mysql\\Processor->handleError('\\xFF\\xDB\\x04#HY000Unknow...')
 #1 /vendor/amphp/mysql/lib/Processor.php(931): Amp\\Mysql\\Processor->parsePayload('\\xFF\\xDB\\x04#HY000Unknow...')
#2 /vendor/amphp/amp/lib/UvReactor.php(424): Amp\\Mysql\\Processor->onRead('0000000016aad06...', Resource id #274, NULL)
#3 /vendor/amphp/amp/lib/UvReactor.php(401): Amp\\UvReactor->invokePollWatcher(Object(stdClass))
#4 [internal function]: Amp\\UvReactor->Amp\\{closure}(Resource id #280, 0, 1, Resource id #274)
#5 /vendor/amphp/amp/lib/UvReactor.php(93): uv_run(Resource id #60, 1)
#6 /vendor/amphp/amp/lib/functions.php(46): Amp\\UvReactor->run(Object(Closure))
#7 /vendor/amphp/aerys/bin/aerys(106): Amp\\run(Object(Closure))
#8 {main}
```

But then I wonder if it should be really possible to reuse a prepared statement after mysql is restarted or if Amp\Mysql should handle this transparently so users won't need to 🤔 