### PR TITLE
Prevents warning when closing connection

### DIFF
--- a/lib/Processor.php
+++ b/lib/Processor.php
@@ -818,7 +818,9 @@ class Processor {
 	public function closeSocket() {
 		\Amp\cancel($this->readWatcher);
 		\Amp\cancel($this->writeWatcher);
-		@fclose($this->socket);
+		if (is_resource($this->socket)) {
+			@fclose($this->socket);
+		}
 		$this->connectionState = self::CLOSED;
 	}
 


### PR DESCRIPTION
Prevents warning when closing connection:

```
fclose(): supplied resource is not a valid stream resource in ./vendor/amphp/mysql/lib/Processor.php:821
```
Otherwise aerys application gets unusable with error handlers like:

```php
set_error_handler(function($errno, $errstr, $file, $line) {
    throw new \Exception("{$errstr} in {$file}:{$line}", $errno);
});
```