### PR TITLE
Fix the typo of license

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "amphp/amp": "^2",
         "amphp/socket": "^0.10"
     },
-    "licence": "MIT",
+    "license": "MIT",
     "authors": [
         {
             "name": "Bob Weinand",


### PR DESCRIPTION
Currently on packagist https://packagist.org/packages/amphp/mysql , it shows no license .