### PR TITLE
Initial implementation of benchmarks

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -37,4 +37,5 @@ return PhpCsFixer\Config::create()
             ->in(__DIR__ . "/examples")
             ->in(__DIR__ . "/lib")
             ->in(__DIR__ . "/test")
+            ->in(__DIR__ . "/benchmarks")
     );

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,10 @@ php:
   - 7.2
   - nightly
 
-matrix:
+jobs:
   include:
-    - addons:
+    - stage: test
+      addons:
          mariadb: 10.1
       php: '7.0'
     - addons:
@@ -43,6 +44,12 @@ matrix:
     - addons:
          mariadb: 10.3
       php: 'nightly'
+    - stage: benchmark
+      php: '7.2'
+      env:
+        - AMP_DEBUG=false
+      script:
+        - PATH=$PATH:$(pwd)/benchmarks/bin vendor/bin/phpbench run --report=aggregate
   allow_failures:
     - php: 'nightly'
     - addons:
@@ -65,7 +72,7 @@ install:
 before_script:
   - echo '<?php $autoloader = require(__DIR__."/../vendor/autoload.php"); const DB_HOST = "localhost"; const DB_USER = "root"; const DB_PASS = "";' > test/bootstrap.php
   - mysql -u root -e "SELECT VERSION(); CREATE DATABASE test; CREATE TABLE test.main (a INT(11), b INT(11)); INSERT INTO test.main VALUES (1, 2), (2, 3), (3, 4), (4, 5), (5, 6);"
- 
+
 script:
   - phpdbg -qrr vendor/bin/phpunit --coverage-text --coverage-clover build/logs/clover.xml
   - PHP_CS_FIXER_IGNORE_ENV=1 php vendor/bin/php-cs-fixer --diff --dry-run -v fix

--- a/benchmarks/AbstractBench.php
+++ b/benchmarks/AbstractBench.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Amp\Mysql\Bench;
+
+class AbstractBench {
+    /** @var string */
+    protected $host = '127.0.0.1';
+
+    /** @var string */
+    protected $user = 'root';
+
+    /** @var string */
+    protected $pass = '';
+}

--- a/benchmarks/QueryBench.php
+++ b/benchmarks/QueryBench.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Amp\Mysql\Bench;
+
+use Amp\Mysql\Connection;
+use Amp\Mysql\Internal\ConnectionConfig;
+use Amp\Mysql\Pool as ConnectionPool;
+use Amp\Mysql\ResultSet;
+use PhpBench\Benchmark\Metadata\Annotations\AfterMethods;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\OutputTimeUnit;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+use function Amp\call;
+use function Amp\Promise\wait;
+
+/**
+ * @BeforeMethods({"init"})
+ * @AfterMethods({"onAfterMethods"})
+ * @Iterations(1)
+ * @Revs(100)
+ * @Warmup(1)
+ * @OutputTimeUnit("milliseconds", precision=5)
+ */
+class QueryBench extends AbstractBench {
+    /** @var  ConnectionPool */
+    protected $connectionPool;
+
+    /** @var  Connection */
+    protected $connection;
+
+    /** @var  \PDO */
+    protected $pdoConnection;
+
+    /** @var int */
+    protected $maxQueries = 10;
+
+    /** @var int */
+    protected $poolLimit = 10;
+
+    public function init() {
+        $config = ConnectionConfig::parseConnectionString("host=$this->host;user=$this->user;pass=$this->pass");
+        $this->connectionPool = new ConnectionPool($config, $this->poolLimit);
+        $connectionPromise = Connection::connect($config);
+        $this->connection = wait($connectionPromise);
+        $this->pdoConnection = new \PDO("mysql:host=$this->host;port=3306", $this->user, $this->pass);
+    }
+
+    public function onAfterMethods() {
+        $this->connectionPool->close();
+        $this->connection->close();
+    }
+
+    public function benchPdoQueries() {
+        foreach (range(1, $this->maxQueries) as $ii) {
+            $resultSet = $this->pdoConnection->query("SELECT $ii");
+            $resultSet->fetch(\PDO::FETCH_ASSOC);
+        }
+    }
+
+    public function benchSyncQueries() {
+        wait(call(function () {
+            $connection = $this->connection;
+            foreach (range(1, $this->maxQueries) as $i) {
+                /** @var ResultSet $resultSet */
+                $resultSet = yield $connection->query("SELECT $i");
+                yield $resultSet->advance();
+            }
+        }));
+    }
+
+    public function benchAsyncQueries() {
+        wait(call(function () {
+            $connection = $this->connection;
+            /** @var ResultSet[] $resultSets */
+            $resultSets = yield array_map(function ($i) use ($connection) {
+                return $connection->query("SELECT $i");
+            }, range(1, $this->maxQueries));
+            yield array_map(function ($resultSet) {
+                /** @var ResultSet $resultSet */
+                return $resultSet->advance();
+            }, $resultSets);
+        }));
+    }
+
+    public function benchAsyncQueriesUsingPool() {
+        wait(call(function () {
+            $connection = $this->connectionPool;
+            /** @var ResultSet[] $resultSets */
+            $resultSets = yield array_map(function ($i) use ($connection) {
+                return $connection->query("SELECT $i");
+            }, range(1, $this->maxQueries));
+            yield array_map(function ($resultSet) {
+                /** @var ResultSet $resultSet */
+                return $resultSet->advance();
+            }, $resultSets);
+        }));
+    }
+}

--- a/benchmarks/bin/php_no_xdebug
+++ b/benchmarks/bin/php_no_xdebug
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+php -n -dopcache.enable_cli=1 -dzend.assertions=-1 "$@"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "require-dev": {
         "phpunit/phpunit": "^6",
         "amphp/phpunit-util": "^1",
-        "friendsofphp/php-cs-fixer": "^2.3"
+        "friendsofphp/php-cs-fixer": "^2.3",
+        "phpbench/phpbench": "^0.13.0"
     },
     "autoload": {
         "psr-4": {
@@ -31,7 +32,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Amp\\Mysql\\Test\\": "test"
+            "Amp\\Mysql\\Test\\": "test",
+            "Amp\\Mysql\\Bench\\": "benchmarks"
         }
     },
     "config": {

--- a/phpbench.json
+++ b/phpbench.json
@@ -1,0 +1,5 @@
+{
+    "bootstrap": "vendor/autoload.php",
+    "path": "benchmarks",
+    "php_binary": "php_no_xdebug"
+}


### PR DESCRIPTION
I think it is important to see some benchmarks comparing with PDO due to pure PHP implementations usually are slow. It is important to know how much slower.
In case of the async driver, we can come up with a conclusion to use the async driver instead of PDO to get a performance boost by executing queries in an async way. 

I'm proposing to run benchmarks right after each build to see the performance. Hope that in future PHP releases pure PHP driver implementation performance will be very close to PDO.

There is only one benchmark with simple query ```SELECT $n``` with following implementations:
1. Sync execution using PDO
2. Sync execution using AmpMySQL
3. Async execution using AmpMySQL
3. Async execution using AmpMySQL with connection pool