### PR TITLE
Rethrow exception in Processor::connect()

### DIFF
--- a/src/Internal/Processor.php
+++ b/src/Internal/Processor.php
@@ -207,7 +207,9 @@ REGEX;
             $this->close();
         });
 
-        (new Coroutine($this->read()))->onResolve(function (): void {
+        $coroutine = new Coroutine($this->read());
+        Promise\rethrow($coroutine);
+        $coroutine->onResolve(function (): void {
             $this->close();
 
             foreach ($this->deferreds as $deferred) {


### PR DESCRIPTION
`Processor::connect()` subscribes to a Coroutine via `onResolve`, but does not handle an exception if something happens within the generator. This leads to unresolved promises without any error output that you can debug. An example of such an error is https://github.com/amphp/mysql/issues/91. Having these changes in place makes sure you receive an error into the loop error handler as last resort.