### PR TITLE
Don't try to base64 decode plain JSON

### DIFF
--- a/src/DataTypes.php
+++ b/src/DataTypes.php
@@ -240,7 +240,7 @@ final class DataTypes
 
     private static function decodeJson(string $data): string
     {
-        if (!\strncmp(self::ENCODED_JSON_PREFIX, $data, \strlen(self::ENCODED_JSON_PREFIX))) {
+        if (\strncmp(self::ENCODED_JSON_PREFIX, $data, \strlen(self::ENCODED_JSON_PREFIX)) !== 0) {
             return $data; // Data was not base-64 encoded.
         }
 


### PR DESCRIPTION
strncmp does not return true/false but "< 0 if string1 is less than string2; > 0 if string1 is greater than string2, and 0 if they are equal." https://www.php.net/manual/en/function.strncmp.php
So the correct comparison should be `strncmp(...) !== 0` instead of `!strncmp(...)` to check if a string has the base64 prefix.
