### PR TITLE
Sort binary result sets correctly

### DIFF
--- a/src/Internal/ConnectionProcessor.php
+++ b/src/Internal/ConnectionProcessor.php
@@ -1147,7 +1147,7 @@ class ConnectionProcessor implements TransientResource
             $column = $this->result->columns[$i] ?? throw new \RuntimeException("Definition missing for column $i");
             $fields[$i] = $column->type->decodeBinary($packet, $offset, $column->flags);
         }
-
+        ksort($fields);
         $this->result->rowFetched($fields);
     }
 

--- a/src/Internal/ConnectionProcessor.php
+++ b/src/Internal/ConnectionProcessor.php
@@ -1147,7 +1147,7 @@ class ConnectionProcessor implements TransientResource
             $column = $this->result->columns[$i] ?? throw new \RuntimeException("Definition missing for column $i");
             $fields[$i] = $column->type->decodeBinary($packet, $offset, $column->flags);
         }
-        ksort($fields);
+        \ksort($fields);
         $this->result->rowFetched($fields);
     }
 


### PR DESCRIPTION
So this pull request doesn't have to be merged as there might be a better way to handle this, but essentially due to the way packet is parsed, the columns are out of order only when the result set contains null columns. Since PHP arrays are always ordered based on insertion order (they are basically just maps), this line https://github.com/amphp/mysql/blob/56a5a9c54ec21e88a8db257aed88c8cceceb3a12/src/Internal/ConnectionProcessor.php#L1137 doesn't do what it intends to do. PHP arrays are ordered based on insertion order, so all null columns are always at the beginning of the result row.

This change just sorts the array keys using ```ksort```. It's a brute fix.