### PR TITLE
Sort binary results v2

### DIFF
--- a/src/Internal/ConnectionProcessor.php
+++ b/src/Internal/ConnectionProcessor.php
@@ -1147,7 +1147,7 @@ class ConnectionProcessor implements TransientResource
             $column = $this->result->columns[$i] ?? throw new \RuntimeException("Definition missing for column $i");
             $fields[$i] = $column->type->decodeBinary($packet, $offset, $column->flags);
         }
-
+        ksort($fields);
         $this->result->rowFetched($fields);
     }
 


### PR DESCRIPTION
This is an alternate way to sort the results using the intended method of prefilling the array keys with any null column values. My only issue with this is ```SplFixedArray::offsetGet```  did not work properly with null values in the array. PHP would think it was not set if you do something like ```$splArray[1] = null;```. It is not clear based on the PHP docs whether this is intended behavior, or not. But I got around it by using ```"\0"``` instead.