### PR TITLE
Return `BIT` columns as integer

### DIFF
--- a/src/MysqlDataType.php
+++ b/src/MysqlDataType.php
@@ -61,7 +61,6 @@ enum MysqlDataType: int
             case self::Blob:
             case self::TinyBlob:
             case self::Geometry:
-            case self::Bit:
             case self::Decimal:
             case self::NewDecimal:
             case self::Json:
@@ -88,6 +87,7 @@ enum MysqlDataType: int
                     ? self::decodeUnsigned16($bytes, $offset)
                     : self::decodeInt16($bytes, $offset);
 
+            case self::Bit:
             case self::Tiny:
                 return $unsigned
                     ? self::decodeUnsigned8($bytes, $offset)

--- a/src/MysqlDataType.php
+++ b/src/MysqlDataType.php
@@ -66,6 +66,10 @@ enum MysqlDataType: int
             case self::Json:
                 return self::decodeString($bytes, $offset);
 
+            case self::Bit:
+                return (int) self::decodeString($bytes, $offset);
+
+
             case self::LongLong:
                 return $unsigned
                     ? self::decodeUnsigned64($bytes, $offset)
@@ -87,7 +91,6 @@ enum MysqlDataType: int
                     ? self::decodeUnsigned16($bytes, $offset)
                     : self::decodeInt16($bytes, $offset);
 
-            case self::Bit:
             case self::Tiny:
                 return $unsigned
                     ? self::decodeUnsigned8($bytes, $offset)


### PR DESCRIPTION
This is motivated by:
> BIT values in MySQL are closer to integers. Although they’re stored as binary data, they represent numeric bit-fields and are used in bitwise operations, which aligns them more with integers than with strings. 
(https://github.com/amphp/mysql/issues/137#issuecomment-2755789840)