### PR TITLE
Use VarString for string parameter encoding in binary protocol

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -56,11 +56,5 @@
                 <directory name="src"/>
             </errorLevel>
         </UnusedClass>
-
-        <InvalidAttribute>
-            <errorLevel type="suppress">
-                <directory name="src"/>
-            </errorLevel>
-        </InvalidAttribute>
     </issueHandlers>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -56,5 +56,11 @@
                 <directory name="src"/>
             </errorLevel>
         </UnusedClass>
+
+        <InvalidAttribute>
+            <errorLevel type="suppress">
+                <directory name="src"/>
+            </errorLevel>
+        </InvalidAttribute>
     </issueHandlers>
 </psalm>

--- a/src/Internal/ConnectionProcessor.php
+++ b/src/Internal/ConnectionProcessor.php
@@ -483,13 +483,20 @@ class ConnectionProcessor implements SqlTransientResource
                     $paramType = $params[$paramId]->getType();
 
                     if (isset($prebound[$paramId])) {
-                        $types[] = MysqlDataType::encodeInt16(MysqlDataType::VarString->value);
+                        $preboundType = match ($paramType) {
+                            MysqlDataType::TinyBlob,
+                            MysqlDataType::Blob,
+                            MysqlDataType::MediumBlob,
+                            MysqlDataType::LongBlob => MysqlDataType::LongBlob,
+                            default => MysqlDataType::VarString,
+                        };
+                        $types[] = MysqlDataType::encodeInt16($preboundType->value);
                         continue;
                     }
 
                     $encodedValue = match ($paramType) {
                         MysqlDataType::Json => MysqlEncodedValue::fromJson($param),
-                        default => MysqlEncodedValue::fromValue($param),
+                        default => MysqlEncodedValue::fromValue($param, $paramType),
                     };
 
                     $types[] = MysqlDataType::encodeInt16($encodedValue->getType()->value);

--- a/src/Internal/ConnectionProcessor.php
+++ b/src/Internal/ConnectionProcessor.php
@@ -490,13 +490,19 @@ class ConnectionProcessor implements SqlTransientResource
                             MysqlDataType::LongBlob => MysqlDataType::LongBlob,
                             default => MysqlDataType::VarString,
                         };
+
                         $types[] = MysqlDataType::encodeInt16($preboundType->value);
+
                         continue;
                     }
 
                     $encodedValue = match ($paramType) {
-                        MysqlDataType::Json => MysqlEncodedValue::fromJson($param),
-                        default => MysqlEncodedValue::fromValue($param, $paramType),
+                        MysqlDataType::TinyBlob,
+                        MysqlDataType::Blob,
+                        MysqlDataType::MediumBlob,
+                        MysqlDataType::LongBlob => MysqlEncodedValue::forTargetType(MysqlDataType::LongBlob, $param),
+                        MysqlDataType::Json => MysqlEncodedValue::forTargetType(MysqlDataType::Json, $param),
+                        default => MysqlEncodedValue::fromValue($param),
                     };
 
                     $types[] = MysqlDataType::encodeInt16($encodedValue->getType()->value);

--- a/src/Internal/MysqlEncodedValue.php
+++ b/src/Internal/MysqlEncodedValue.php
@@ -7,11 +7,11 @@ use Amp\Mysql\MysqlDataType;
 /** @internal */
 final class MysqlEncodedValue
 {
-    public static function fromValue(mixed $param): self
+    public static function fromValue(mixed $param, ?MysqlDataType $targetType = null): self
     {
         switch (\get_debug_type($param)) {
             case "string":
-                return new self(MysqlDataType::VarString, MysqlDataType::encodeInt(\strlen($param)) . $param);
+                return new self(self::stringTypeFor($targetType), MysqlDataType::encodeInt(\strlen($param)) . $param);
 
             case "int":
                 if ($param >= -(1 << 7) && $param < (1 << 7)) {
@@ -40,15 +40,33 @@ final class MysqlEncodedValue
 
             default:
                 if ($param instanceof \BackedEnum) {
-                    return self::fromValue($param->value);
+                    return self::fromValue($param->value, $targetType);
                 }
 
                 if ($param instanceof \Stringable) {
-                    return self::fromValue((string) $param);
+                    return self::fromValue((string) $param, $targetType);
                 }
 
                 throw new \TypeError("Unexpected type for query parameter: " . \get_debug_type($param));
         }
+    }
+
+    /**
+     * Picks the wire type for a PHP string parameter. Blob-family targets keep
+     * the binary (charset 63) interpretation of LongBlob so raw bytes are not
+     * transcoded against the connection charset; everything else uses VarString
+     * so MariaDB's native UUID column type and similar string-typed columns
+     * parse the value correctly.
+     */
+    private static function stringTypeFor(?MysqlDataType $targetType): MysqlDataType
+    {
+        return match ($targetType) {
+            MysqlDataType::TinyBlob,
+            MysqlDataType::Blob,
+            MysqlDataType::MediumBlob,
+            MysqlDataType::LongBlob => MysqlDataType::LongBlob,
+            default => MysqlDataType::VarString,
+        };
     }
 
     public static function fromJson(?string $json): self

--- a/src/Internal/MysqlEncodedValue.php
+++ b/src/Internal/MysqlEncodedValue.php
@@ -7,11 +7,11 @@ use Amp\Mysql\MysqlDataType;
 /** @internal */
 final class MysqlEncodedValue
 {
-    public static function fromValue(mixed $param, ?MysqlDataType $targetType = null): self
+    public static function fromValue(mixed $param): self
     {
         switch (\get_debug_type($param)) {
             case "string":
-                return new self(self::stringTypeFor($targetType), MysqlDataType::encodeInt(\strlen($param)) . $param);
+                return new self(MysqlDataType::VarString, MysqlDataType::encodeInt(\strlen($param)) . $param);
 
             case "int":
                 if ($param >= -(1 << 7) && $param < (1 << 7)) {
@@ -40,42 +40,36 @@ final class MysqlEncodedValue
 
             default:
                 if ($param instanceof \BackedEnum) {
-                    return self::fromValue($param->value, $targetType);
+                    return self::fromValue($param->value);
                 }
 
                 if ($param instanceof \Stringable) {
-                    return self::fromValue((string) $param, $targetType);
+                    return self::fromValue((string) $param);
                 }
 
                 throw new \TypeError("Unexpected type for query parameter: " . \get_debug_type($param));
         }
     }
 
-    /**
-     * Picks the wire type for a PHP string parameter. Blob-family targets keep
-     * the binary (charset 63) interpretation of LongBlob so raw bytes are not
-     * transcoded against the connection charset; everything else uses VarString
-     * so MariaDB's native UUID column type and similar string-typed columns
-     * parse the value correctly.
-     */
-    private static function stringTypeFor(?MysqlDataType $targetType): MysqlDataType
+    public static function forTargetType(MysqlDataType $targetType, mixed $data): self
     {
-        return match ($targetType) {
-            MysqlDataType::TinyBlob,
-            MysqlDataType::Blob,
-            MysqlDataType::MediumBlob,
-            MysqlDataType::LongBlob => MysqlDataType::LongBlob,
-            default => MysqlDataType::VarString,
-        };
-    }
-
-    public static function fromJson(?string $json): self
-    {
-        if ($json === null) {
+        if ($data === null) {
             return new self(MysqlDataType::Null, "");
         }
 
-        return new self(MysqlDataType::Json, MysqlDataType::encodeInt(\strlen($json)) . $json);
+        if ($data instanceof \Stringable) {
+            $data = (string) $data;
+        }
+
+        if (!\is_string($data)) {
+            throw new \TypeError(\sprintf(
+                "Expected string or null for %s column data, got %s",
+                $targetType->name,
+                \get_debug_type($data),
+            ));
+        }
+
+        return new self($targetType, MysqlDataType::encodeInt(\strlen($data)) . $data);
     }
 
     private function __construct(

--- a/src/Internal/MysqlEncodedValue.php
+++ b/src/Internal/MysqlEncodedValue.php
@@ -11,7 +11,7 @@ final class MysqlEncodedValue
     {
         switch (\get_debug_type($param)) {
             case "string":
-                return new self(MysqlDataType::LongBlob, MysqlDataType::encodeInt(\strlen($param)) . $param);
+                return new self(MysqlDataType::VarString, MysqlDataType::encodeInt(\strlen($param)) . $param);
 
             case "int":
                 if ($param >= -(1 << 7) && $param < (1 << 7)) {

--- a/test/MysqlEncodedValueTest.php
+++ b/test/MysqlEncodedValueTest.php
@@ -8,43 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class MysqlEncodedValueTest extends TestCase
 {
-    /**
-     * @return iterable<string, array{MysqlDataType|null, MysqlDataType}>
-     */
-    public function provideStringTargets(): iterable
-    {
-        yield 'no target (legacy default)' => [null, MysqlDataType::VarString];
-        yield 'varchar' => [MysqlDataType::Varchar, MysqlDataType::VarString];
-        yield 'string' => [MysqlDataType::String, MysqlDataType::VarString];
-        yield 'var_string' => [MysqlDataType::VarString, MysqlDataType::VarString];
-        yield 'tiny_blob' => [MysqlDataType::TinyBlob, MysqlDataType::LongBlob];
-        yield 'blob' => [MysqlDataType::Blob, MysqlDataType::LongBlob];
-        yield 'medium_blob' => [MysqlDataType::MediumBlob, MysqlDataType::LongBlob];
-        yield 'long_blob' => [MysqlDataType::LongBlob, MysqlDataType::LongBlob];
-        yield 'bit' => [MysqlDataType::Bit, MysqlDataType::VarString];
-        yield 'enum' => [MysqlDataType::Enum, MysqlDataType::VarString];
-        yield 'set' => [MysqlDataType::Set, MysqlDataType::VarString];
-        yield 'geometry' => [MysqlDataType::Geometry, MysqlDataType::VarString];
-    }
-
-    /**
-     * @dataProvider provideStringTargets
-     */
-    public function testStringPicksTypeBasedOnTarget(?MysqlDataType $target, MysqlDataType $expected): void
-    {
-        $encoded = MysqlEncodedValue::fromValue('hello', $target);
-
-        self::assertSame($expected, $encoded->getType());
-    }
-
-    public function testBinaryPayloadIntoBlobStaysLongBlob(): void
-    {
-        $encoded = MysqlEncodedValue::fromValue(\random_bytes(64), MysqlDataType::Blob);
-
-        self::assertSame(MysqlDataType::LongBlob, $encoded->getType());
-    }
-
-    public function testStringableIntoBlobStaysLongBlob(): void
+    public function testStringable(): void
     {
         $stringable = new class implements \Stringable {
             public function __toString(): string
@@ -53,36 +17,22 @@ class MysqlEncodedValueTest extends TestCase
             }
         };
 
-        $encoded = MysqlEncodedValue::fromValue($stringable, MysqlDataType::LongBlob);
+        $encoded = MysqlEncodedValue::forTargetType(MysqlDataType::LongBlob, $stringable);
 
         self::assertSame(MysqlDataType::LongBlob, $encoded->getType());
     }
 
-    public function testBackedEnumIntoStringTargetUsesVarString(): void
-    {
-        $enum = StringTargetEnum::Foo;
-
-        $encoded = MysqlEncodedValue::fromValue($enum, MysqlDataType::Varchar);
-
-        self::assertSame(MysqlDataType::VarString, $encoded->getType());
-    }
-
-    public function testIntegerEncodingIgnoresTarget(): void
-    {
-        $encoded = MysqlEncodedValue::fromValue(1, MysqlDataType::LongBlob);
-
-        self::assertSame(MysqlDataType::Tiny, $encoded->getType());
-    }
-
     public function testNullEncodingIgnoresTarget(): void
     {
-        $encoded = MysqlEncodedValue::fromValue(null, MysqlDataType::LongBlob);
+        $encoded = MysqlEncodedValue::forTargetType(MysqlDataType::LongBlob, null);
 
         self::assertSame(MysqlDataType::Null, $encoded->getType());
     }
-}
 
-enum StringTargetEnum: string
-{
-    case Foo = 'foo';
+    public function testNonStringValueThrows(): void
+    {
+        self::expectException(\TypeError::class);
+
+        MysqlEncodedValue::forTargetType(MysqlDataType::LongBlob, 1);
+    }
 }

--- a/test/MysqlEncodedValueTest.php
+++ b/test/MysqlEncodedValueTest.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+
+namespace Amp\Mysql\Test;
+
+use Amp\Mysql\Internal\MysqlEncodedValue;
+use Amp\Mysql\MysqlDataType;
+use PHPUnit\Framework\TestCase;
+
+class MysqlEncodedValueTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{MysqlDataType|null, MysqlDataType}>
+     */
+    public function provideStringTargets(): iterable
+    {
+        yield 'no target (legacy default)' => [null, MysqlDataType::VarString];
+        yield 'varchar' => [MysqlDataType::Varchar, MysqlDataType::VarString];
+        yield 'string' => [MysqlDataType::String, MysqlDataType::VarString];
+        yield 'var_string' => [MysqlDataType::VarString, MysqlDataType::VarString];
+        yield 'tiny_blob' => [MysqlDataType::TinyBlob, MysqlDataType::LongBlob];
+        yield 'blob' => [MysqlDataType::Blob, MysqlDataType::LongBlob];
+        yield 'medium_blob' => [MysqlDataType::MediumBlob, MysqlDataType::LongBlob];
+        yield 'long_blob' => [MysqlDataType::LongBlob, MysqlDataType::LongBlob];
+        yield 'bit' => [MysqlDataType::Bit, MysqlDataType::VarString];
+        yield 'enum' => [MysqlDataType::Enum, MysqlDataType::VarString];
+        yield 'set' => [MysqlDataType::Set, MysqlDataType::VarString];
+        yield 'geometry' => [MysqlDataType::Geometry, MysqlDataType::VarString];
+    }
+
+    /**
+     * @dataProvider provideStringTargets
+     */
+    public function testStringPicksTypeBasedOnTarget(?MysqlDataType $target, MysqlDataType $expected): void
+    {
+        $encoded = MysqlEncodedValue::fromValue('hello', $target);
+
+        self::assertSame($expected, $encoded->getType());
+    }
+
+    public function testBinaryPayloadIntoBlobStaysLongBlob(): void
+    {
+        $encoded = MysqlEncodedValue::fromValue(\random_bytes(64), MysqlDataType::Blob);
+
+        self::assertSame(MysqlDataType::LongBlob, $encoded->getType());
+    }
+
+    public function testStringableIntoBlobStaysLongBlob(): void
+    {
+        $stringable = new class implements \Stringable {
+            public function __toString(): string
+            {
+                return 'cast me';
+            }
+        };
+
+        $encoded = MysqlEncodedValue::fromValue($stringable, MysqlDataType::LongBlob);
+
+        self::assertSame(MysqlDataType::LongBlob, $encoded->getType());
+    }
+
+    public function testBackedEnumIntoStringTargetUsesVarString(): void
+    {
+        $enum = StringTargetEnum::Foo;
+
+        $encoded = MysqlEncodedValue::fromValue($enum, MysqlDataType::Varchar);
+
+        self::assertSame(MysqlDataType::VarString, $encoded->getType());
+    }
+
+    public function testIntegerEncodingIgnoresTarget(): void
+    {
+        $encoded = MysqlEncodedValue::fromValue(1, MysqlDataType::LongBlob);
+
+        self::assertSame(MysqlDataType::Tiny, $encoded->getType());
+    }
+
+    public function testNullEncodingIgnoresTarget(): void
+    {
+        $encoded = MysqlEncodedValue::fromValue(null, MysqlDataType::LongBlob);
+
+        self::assertSame(MysqlDataType::Null, $encoded->getType());
+    }
+}
+
+enum StringTargetEnum: string
+{
+    case Foo = 'foo';
+}

--- a/test/MysqlLinkTest.php
+++ b/test/MysqlLinkTest.php
@@ -449,7 +449,7 @@ abstract class MysqlLinkTest extends MysqlTestCase
         return \array_map(
             fn (mixed $data) => [$data, \json_encode($data, \JSON_THROW_ON_ERROR)],
             [
-                'object' => (object)['key' => 'value'],
+                'object' => (object) ['key' => 'value'],
                 'array' => [1, 2, 3],
                 'string' => 'string',
                 'integer' => 123,

--- a/test/MysqlLinkTest.php
+++ b/test/MysqlLinkTest.php
@@ -317,14 +317,14 @@ abstract class MysqlLinkTest extends MysqlTestCase
     {
         $db = $this->getLink();
 
-        $result = $db->execute("SELECT * FROM test.main WHERE a = ? OR b = ?", [2, 5]);
+        $result = $db->execute("SELECT id, a, b, c, d FROM test.main WHERE a = ? OR b = ?", [2, 5]);
         $this->assertInstanceOf(MysqlResult::class, $result);
         $got = [];
         foreach ($result as $row) {
             $got[] = \array_values($row);
         }
         $this->assertCount(2, $got);
-        $this->assertSame([[2, 2, 3, self::EPOCH, 'b', null], [4, 4, 5, self::EPOCH, 'd', null]], $got);
+        $this->assertSame([[2, 2, 3, self::EPOCH, 'b'], [4, 4, 5, self::EPOCH, 'd']], $got);
 
         $result = $db->execute("INSERT INTO main (a, b) VALUES (:a, :b)", ["a" => 10, "b" => 11, "c" => '1970-01-01 00:00:00']);
         $this->assertInstanceOf(MysqlResult::class, $result);
@@ -444,18 +444,73 @@ abstract class MysqlLinkTest extends MysqlTestCase
         $db->close();
     }
 
-    public function testBindJson(): void
+    public function provideJsonData(): array
     {
-        $json = '{"key": "value"}';
+        return \array_map(
+            fn (mixed $data) => [$data, \json_encode($data, \JSON_THROW_ON_ERROR)],
+            [
+                'object' => (object)['key' => 'value'],
+                'array' => [1, 2, 3],
+                'string' => 'string',
+                'integer' => 123,
+                'float' => 3.14159,
+                'boolean' => true,
+                'null' => null,
+            ],
+        );
+    }
 
-        $statement = $this->getLink()->prepare("SELECT CAST(? AS JSON) AS json_data");
-        $statement->bind(0, $json);
+    /**
+     * @dataProvider provideJsonData
+     */
+    public function testJsonData(mixed $data, string $json): void
+    {
+        $db = $this->getLink();
 
-        $result = $statement->execute();
+        $transaction = $db->beginTransaction();
 
-        foreach ($result as $row) {
-            self::assertSame($json, $row['json_data']);
+        try {
+            $result = $transaction->execute("INSERT INTO main SET f = :json", ['json' => $json]);
+
+            self::assertSame($result->getRowCount(), 1);
+            $id = $result->getLastInsertId();
+            self::assertNotEmpty($id);
+
+            $result = $transaction->execute("SELECT f FROM main WHERE id = :id", ['id' => $id]);
+            self::assertEquals($data, \json_decode($result->fetchRow()['f'], flags: \JSON_THROW_ON_ERROR));
+        } finally {
+            $transaction->rollback();
         }
+
+        $db->close();
+    }
+
+    /**
+     * @dataProvider provideJsonData
+     */
+    public function testBindJsonData(mixed $data, string $json): void
+    {
+        $db = $this->getLink();
+
+        $transaction = $db->beginTransaction();
+
+        try {
+            $statement = $transaction->prepare("INSERT INTO main SET f = ?");
+            $statement->bind(0, $json);
+
+            $result = $statement->execute();
+
+            self::assertSame($result->getRowCount(), 1);
+            $id = $result->getLastInsertId();
+            self::assertNotEmpty($id);
+
+            $result = $transaction->execute("SELECT f FROM main WHERE id = :id", ['id' => $id]);
+            self::assertEquals($data, \json_decode($result->fetchRow()['f'], flags: \JSON_THROW_ON_ERROR));
+        } finally {
+            $transaction->rollback();
+        }
+
+        $db->close();
     }
 
     public function provideBlobData(): iterable
@@ -477,12 +532,40 @@ abstract class MysqlLinkTest extends MysqlTestCase
         try {
             $result = $transaction->execute("INSERT INTO main SET e = :data", ['data' => $data]);
 
-            $this->assertSame($result->getRowCount(), 1);
+            self::assertSame($result->getRowCount(), 1);
             $id = $result->getLastInsertId();
-            $this->assertNotEmpty($id);
+            self::assertNotEmpty($id);
 
             $result = $transaction->execute("SELECT e FROM main WHERE id = :id", ['id' => $id]);
-            $this->assertSame($data, $result->fetchRow()['e']);
+            self::assertSame($data, $result->fetchRow()['e']);
+        } finally {
+            $transaction->rollback();
+        }
+
+        $db->close();
+    }
+
+    /**
+     * @dataProvider provideBlobData
+     */
+    public function testBindBlobData(string $data): void
+    {
+        $db = $this->getLink();
+
+        $transaction = $db->beginTransaction();
+
+        try {
+            $statement = $transaction->prepare("INSERT INTO main SET e = ?");
+            $statement->bind(0, $data);
+
+            $result = $statement->execute();
+
+            self::assertSame($result->getRowCount(), 1);
+            $id = $result->getLastInsertId();
+            self::assertNotEmpty($id);
+
+            $result = $transaction->execute("SELECT e FROM main WHERE id = :id", ['id' => $id]);
+            self::assertSame($data, $result->fetchRow()['e']);
         } finally {
             $transaction->rollback();
         }

--- a/test/MysqlLinkTest.php
+++ b/test/MysqlLinkTest.php
@@ -233,7 +233,7 @@ abstract class MysqlLinkTest extends MysqlTestCase
         $stmt = $db->prepare("SELECT * FROM main WHERE a = ? OR b = ?");
         $result = $stmt->execute([1, 8]);
         $this->assertInstanceOf(MysqlResult::class, $result);
-        $this->assertSame(5, $result->getColumnCount());
+        $this->assertSame(EXPECTED_COLUMN_COUNT, $result->getColumnCount());
         $got = [];
         foreach ($result as $row) {
             $got[] = \array_values($row);
@@ -243,7 +243,7 @@ abstract class MysqlLinkTest extends MysqlTestCase
         $stmt = $db->prepare("SELECT * FROM main WHERE a = :a OR b = ?");
         $result = $stmt->execute(["a" => 2, 5]);
         $this->assertInstanceOf(MysqlResult::class, $result);
-        $this->assertSame(5, $result->getColumnCount());
+        $this->assertSame(EXPECTED_COLUMN_COUNT, $result->getColumnCount());
         $got = [];
         foreach ($result as $row) {
             $got[] = \array_values($row);
@@ -324,7 +324,7 @@ abstract class MysqlLinkTest extends MysqlTestCase
             $got[] = \array_values($row);
         }
         $this->assertCount(2, $got);
-        $this->assertSame([[2, 2, 3, self::EPOCH, 'b'], [4, 4, 5, self::EPOCH, 'd']], $got);
+        $this->assertSame([[2, 2, 3, self::EPOCH, 'b', null], [4, 4, 5, self::EPOCH, 'd', null]], $got);
 
         $result = $db->execute("INSERT INTO main (a, b) VALUES (:a, :b)", ["a" => 10, "b" => 11, "c" => '1970-01-01 00:00:00']);
         $this->assertInstanceOf(MysqlResult::class, $result);
@@ -456,5 +456,31 @@ abstract class MysqlLinkTest extends MysqlTestCase
         foreach ($result as $row) {
             self::assertSame($json, $row['json_data']);
         }
+    }
+
+    public function provideBlobData(): iterable
+    {
+        foreach (\range(0, 9) as $i) {
+            yield 'blob-data-' . $i => [\random_bytes(10)];
+        }
+    }
+
+    /**
+     * @dataProvider provideBlobData
+     */
+    public function testBlobData(string $data): void
+    {
+        $db = $this->getLink();
+
+        $result = $db->execute("INSERT INTO main SET e = :data", ['data' => $data]);
+
+        $this->assertSame($result->getRowCount(), 1);
+        $id = $result->getLastInsertId();
+        $this->assertNotEmpty($id);
+
+        $result = $db->execute("SELECT e FROM main WHERE id = :id", ['id' => $id]);
+        $this->assertSame($data, $result->fetchRow()['e']);
+
+        $db->close();
     }
 }

--- a/test/MysqlLinkTest.php
+++ b/test/MysqlLinkTest.php
@@ -472,14 +472,20 @@ abstract class MysqlLinkTest extends MysqlTestCase
     {
         $db = $this->getLink();
 
-        $result = $db->execute("INSERT INTO main SET e = :data", ['data' => $data]);
+        $transaction = $db->beginTransaction();
 
-        $this->assertSame($result->getRowCount(), 1);
-        $id = $result->getLastInsertId();
-        $this->assertNotEmpty($id);
+        try {
+            $result = $transaction->execute("INSERT INTO main SET e = :data", ['data' => $data]);
 
-        $result = $db->execute("SELECT e FROM main WHERE id = :id", ['id' => $id]);
-        $this->assertSame($data, $result->fetchRow()['e']);
+            $this->assertSame($result->getRowCount(), 1);
+            $id = $result->getLastInsertId();
+            $this->assertNotEmpty($id);
+
+            $result = $transaction->execute("SELECT e FROM main WHERE id = :id", ['id' => $id]);
+            $this->assertSame($data, $result->fetchRow()['e']);
+        } finally {
+            $transaction->rollback();
+        }
 
         $db->close();
     }

--- a/test/initialize.php
+++ b/test/initialize.php
@@ -2,7 +2,7 @@
 
 namespace Amp\Mysql\Test;
 
-const EXPECTED_COLUMN_COUNT = 6;
+const EXPECTED_COLUMN_COUNT = 7;
 
 function initialize(\mysqli $db): void
 {
@@ -16,6 +16,7 @@ function initialize(\mysqli $db): void
             c DATETIME NULL,
             d VARCHAR(255) NULL,
             e BLOB NULL,
+            f JSON NULL,
             PRIMARY KEY (id)
         );
     SQL);

--- a/test/initialize.php
+++ b/test/initialize.php
@@ -2,14 +2,35 @@
 
 namespace Amp\Mysql\Test;
 
+const EXPECTED_COLUMN_COUNT = 6;
+
 function initialize(\mysqli $db): void
 {
     $db->query("CREATE DATABASE test");
 
-    $db->query("CREATE TABLE test.main (id INT NOT NULL AUTO_INCREMENT, a INT, b INT, c DATETIME, d VARCHAR(255), PRIMARY KEY (id))");
+    $db->query(<<<SQL
+        CREATE TABLE test.main (
+            id INT NOT NULL AUTO_INCREMENT,
+            a INT NULL,
+            b INT NULL,
+            c DATETIME NULL,
+            d VARCHAR(255) NULL,
+            e BLOB NULL,
+            PRIMARY KEY (id)
+        );
+    SQL);
 
     $epoch = MysqlLinkTest::EPOCH;
-    $db->query("INSERT INTO test.main (a, b, c, d) VALUES (1, 2, '$epoch', 'a'), (2, 3, '$epoch', 'b'), (3, 4, '$epoch', 'c'), (4, 5, '$epoch', 'd'), (5, 6, '$epoch', 'e')");
+    $db->query(<<<SQL
+        INSERT INTO
+            test.main (a, b, c, d)
+        VALUES
+            (1, 2, '$epoch', 'a'),
+            (2, 3, '$epoch', 'b'),
+            (3, 4, '$epoch', 'c'),
+            (4, 5, '$epoch', 'd'), 
+            (5, 6, '$epoch', 'e')
+    SQL);
 
     $db->close();
 }


### PR DESCRIPTION
## Summary

- String parameters in prepared statements are currently encoded as `MYSQL_TYPE_LONG_BLOB` (0xfb), which tells the server to treat values as raw binary data
- This breaks MariaDB's native `UUID` column type (introduced in MariaDB 10.7), which requires string-typed parameters to trigger string→UUID parsing
- Changes the type to `MYSQL_TYPE_VAR_STRING` (0xfd), which is more semantically correct for PHP string values and matches MySQL's own C API behavior for string binds

## Why this matters

MariaDB 10.7+ introduced a native `UUID` column type that stores UUIDs as 16-byte binary internally. When a prepared statement parameter is typed as `LONG_BLOB`, MariaDB interprets the 36-byte ASCII UUID string as raw bytes instead of parsing the human-readable format. With `VAR_STRING`, MariaDB correctly converts the string representation to its internal format.

## Safety

The wire encoding (length-prefixed bytes) is identical for both `LongBlob` and `VarString` — only the 2-byte type header in `COM_STMT_EXECUTE` changes. All existing tests pass (136/136).

This is effectively a no-op for all standard MySQL/MariaDB column types (`VARCHAR`, `CHAR`, `TEXT`, `BLOB`, etc.) since both types trigger the same implicit conversion paths. The difference only surfaces for MariaDB-specific types like `UUID` that distinguish between string and binary parameter sources.

## Suggestion

The current test suite only runs against MySQL. Adding MariaDB to the CI matrix (related: #80) would help catch driver-specific issues like this. Happy to help with that in a follow-up PR if there's interest.