### PR TITLE
Update Psalm to 6.16.1 to fix #[\Override] false positives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Get Composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-dir)"
+        run: echo "dir=$(composer config cache-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
         uses: actions/cache@v5
@@ -72,7 +72,7 @@ jobs:
         if: matrix.psalm == 'skip'
 
       - name: Install dependencies
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 5
           max_attempts: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         if: matrix.psalm == 'skip'
 
       - name: Install dependencies
-        uses: nick-invision/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 5
           max_attempts: 5

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "amphp/phpunit-util": "^3",
         "amphp/php-cs-fixer-config": "^2",
         "phpbench/phpbench": "^1.2.6",
-        "psalm/phar": "6.15.1"
+        "psalm/phar": "^6.16.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary

- Psalm 6.15.1 reports `InvalidAttribute` errors for `#[\Override]` on PHP 8.4.19+
- This breaks CI after GitHub's runner update from PHP 8.4.18 to 8.4.19
- Psalm 6.16.1 resolves these false positives

Noticed while working on #142 — all PRs against 3.x will fail static analysis until this is merged.