### PR TITLE
Add MariaDB CI job and integration test for native UUID column

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,16 @@ jobs:
           - operating-system: 'ubuntu-latest'
             php-version: '8.5'
 
+          - operating-system: 'ubuntu-latest'
+            php-version: '8.4'
+            db-version: 'MariaDB'
+            job-description: 'with MariaDB'
+
+          - operating-system: 'ubuntu-latest'
+            php-version: '8.5'
+            db-version: 'MariaDB'
+            job-description: 'with MariaDB'
+
     name: PHP ${{ matrix.php-version }} ${{ matrix.job-description }}
 
     runs-on: ${{ matrix.operating-system }}
@@ -38,6 +48,17 @@ jobs:
       - name: Setup MySQL
         run: |
           sudo systemctl start mysql
+        if: matrix.db-version != 'MariaDB'
+
+      - name: Setup MariaDB
+        run: |
+          sudo systemctl stop mysql
+          sudo apt-get update
+          sudo apt-get install -y mariadb-server
+          sudo systemctl start mariadb
+          sudo mariadb -e "ALTER USER 'root'@'localhost' IDENTIFIED VIA mysql_native_password USING PASSWORD('root'); FLUSH PRIVILEGES;"
+          mariadb --version
+        if: matrix.db-version == 'MariaDB'
 
       - name: Set git to use LF
         run: |
@@ -86,79 +107,10 @@ jobs:
 
       - name: Run static analysis
         run: vendor/bin/psalm.phar
-        if: matrix.psalm != 'skip'
+        if: matrix.db-version != 'MariaDB' && matrix.psalm != 'skip'
 
       - name: Run style fixer
         env:
           PHP_CS_FIXER_IGNORE_ENV: 1
         run: vendor/bin/php-cs-fixer --diff --dry-run -v fix
-        if: runner.os != 'Windows' && matrix.style-fix != 'none'
-
-  tests-mariadb:
-    strategy:
-      matrix:
-        include:
-          - operating-system: 'ubuntu-latest'
-            php-version: '8.4'
-
-          - operating-system: 'ubuntu-latest'
-            php-version: '8.5'
-
-    name: PHP ${{ matrix.php-version }} (MariaDB)
-
-    runs-on: ${{ matrix.operating-system }}
-
-    env:
-      MYSQL_DATABASE: test
-      MYSQL_USER: root
-      MYSQL_PASSWORD: root
-
-    steps:
-      - name: Setup MariaDB
-        run: |
-          sudo systemctl stop mysql
-          sudo apt-get update
-          sudo apt-get install -y mariadb-server
-          sudo systemctl start mariadb
-          sudo mariadb -e "ALTER USER 'root'@'localhost' IDENTIFIED VIA mysql_native_password USING PASSWORD('root'); FLUSH PRIVILEGES;"
-          mariadb --version
-
-      - name: Set git to use LF
-        run: |
-          git config --global core.autocrlf false
-          git config --global core.eol lf
-
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache dependencies
-        uses: actions/cache@v5
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: composer-mariadb-${{ runner.os }}-${{ matrix.php-version }}-${{ hashFiles('**/composer.*') }}
-          restore-keys: |
-            composer-mariadb-${{ runner.os }}-${{ matrix.php-version }}-
-            composer-${{ runner.os }}-${{ matrix.php-version }}-
-            composer-${{ runner.os }}-
-
-      - name: Install dependencies
-        uses: nick-fields/retry@v4
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          retry_wait_seconds: 30
-          command: |
-            composer update --optimize-autoloader --no-interaction --no-progress
-            composer info -D
-
-      - name: Run tests
-        run: vendor/bin/phpunit --bootstrap .github/workflows/bootstrap.php
+        if: runner.os != 'Windows' && matrix.db-version != 'MariaDB' && matrix.style-fix != 'none'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,5 +160,5 @@ jobs:
             composer update --optimize-autoloader --no-interaction --no-progress
             composer info -D
 
-      - name: Run MariaDB UUID test
-        run: vendor/bin/phpunit --bootstrap .github/workflows/bootstrap.php --filter MariaDbUuidTest
+      - name: Run tests
+        run: vendor/bin/phpunit --bootstrap .github/workflows/bootstrap.php

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,72 @@ jobs:
           PHP_CS_FIXER_IGNORE_ENV: 1
         run: vendor/bin/php-cs-fixer --diff --dry-run -v fix
         if: runner.os != 'Windows' && matrix.style-fix != 'none'
+
+  tests-mariadb:
+    strategy:
+      matrix:
+        include:
+          - operating-system: 'ubuntu-latest'
+            php-version: '8.4'
+
+          - operating-system: 'ubuntu-latest'
+            php-version: '8.5'
+
+    name: PHP ${{ matrix.php-version }} (MariaDB)
+
+    runs-on: ${{ matrix.operating-system }}
+
+    env:
+      MYSQL_DATABASE: test
+      MYSQL_USER: root
+      MYSQL_PASSWORD: root
+
+    steps:
+      - name: Setup MariaDB
+        run: |
+          sudo systemctl stop mysql
+          sudo apt-get update
+          sudo apt-get install -y mariadb-server
+          sudo systemctl start mariadb
+          sudo mariadb -e "ALTER USER 'root'@'localhost' IDENTIFIED VIA mysql_native_password USING PASSWORD('root'); FLUSH PRIVILEGES;"
+          mariadb --version
+
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: composer-mariadb-${{ runner.os }}-${{ matrix.php-version }}-${{ hashFiles('**/composer.*') }}
+          restore-keys: |
+            composer-mariadb-${{ runner.os }}-${{ matrix.php-version }}-
+            composer-${{ runner.os }}-${{ matrix.php-version }}-
+            composer-${{ runner.os }}-
+
+      - name: Install dependencies
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          retry_wait_seconds: 30
+          command: |
+            composer update --optimize-autoloader --no-interaction --no-progress
+            composer info -D
+
+      - name: Run MariaDB UUID test
+        run: vendor/bin/phpunit --bootstrap .github/workflows/bootstrap.php --filter MariaDbUuidTest

--- a/test/MariaDbUuidTest.php
+++ b/test/MariaDbUuidTest.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+namespace Amp\Mysql\Test;
+
+use Amp\Mysql\SocketMysqlConnector;
+
+/**
+ * Exercises the prepared-statement parameter encoding path against MariaDB's
+ * native UUID column type. Regresses if MysqlEncodedValue::stringTypeFor() ever
+ * stops picking VarString for string-family targets (see #142).
+ */
+class MariaDbUuidTest extends MysqlTestCase
+{
+    private const FIXTURE_UUID = '550e8400-e29b-41d4-a716-446655440000';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $db = (new SocketMysqlConnector)->connect($this->getConfig());
+
+        $version = '';
+        foreach ($db->query('SELECT VERSION() AS v') as $row) {
+            $version = (string) $row['v'];
+        }
+
+        if (!\str_contains($version, 'MariaDB')) {
+            $db->close();
+            self::markTestSkipped('Requires MariaDB (got: ' . $version . ')');
+        }
+
+        // Native UUID column type landed in MariaDB 10.7.
+        if (\preg_match('/^(\d+)\.(\d+)/', $version, $matches) !== 1
+            || \version_compare($matches[1] . '.' . $matches[2], '10.7', '<')) {
+            $db->close();
+            self::markTestSkipped('Requires MariaDB >= 10.7 for native UUID column (got: ' . $version . ')');
+        }
+
+        $db->query('DROP TABLE IF EXISTS uuid_test');
+        $db->query('CREATE TABLE uuid_test (id UUID PRIMARY KEY, label VARCHAR(64))');
+        $db->close();
+    }
+
+    protected function tearDown(): void
+    {
+        $db = (new SocketMysqlConnector)->connect($this->getConfig());
+        $db->query('DROP TABLE IF EXISTS uuid_test');
+        $db->close();
+
+        parent::tearDown();
+    }
+
+    public function testPreparedInsertRoundTripsNativeUuid(): void
+    {
+        $db = (new SocketMysqlConnector)->connect($this->getConfig());
+
+        $statement = $db->prepare('INSERT INTO uuid_test (id, label) VALUES (?, ?)');
+        $statement->execute([self::FIXTURE_UUID, 'fixture']);
+
+        $rows = [];
+        foreach ($db->query('SELECT id, label FROM uuid_test') as $row) {
+            $rows[] = $row;
+        }
+
+        $db->close();
+
+        self::assertCount(1, $rows);
+        self::assertSame(self::FIXTURE_UUID, (string) $rows[0]['id']);
+        self::assertSame('fixture', $rows[0]['label']);
+    }
+}

--- a/test/MariaDbUuidTest.php
+++ b/test/MariaDbUuidTest.php
@@ -2,6 +2,7 @@
 
 namespace Amp\Mysql\Test;
 
+use Amp\Mysql\MysqlConnection;
 use Amp\Mysql\SocketMysqlConnector;
 
 /**
@@ -12,56 +13,43 @@ class MariaDbUuidTest extends MysqlTestCase
 {
     private const FIXTURE_UUID = '550e8400-e29b-41d4-a716-446655440000';
 
+    private MysqlConnection $db;
+
     protected function setUp(): void
     {
         parent::setUp();
 
-        $db = (new SocketMysqlConnector)->connect($this->getConfig());
-
-        $version = '';
-        foreach ($db->query('SELECT VERSION() AS v') as $row) {
-            $version = (string) $row['v'];
-        }
-
-        if (!\str_contains($version, 'MariaDB')) {
-            $db->close();
-            self::markTestSkipped('Requires MariaDB (got: ' . $version . ')');
-        }
+        $version = $this->getDbVersion();
 
         // Native UUID column type landed in MariaDB 10.7.
         if (\preg_match('/^(\d+)\.(\d+)/', $version, $matches) !== 1
-            || \version_compare($matches[1] . '.' . $matches[2], '10.7', '<')) {
-            $db->close();
+            || \version_compare($matches[1] . '.' . $matches[2], '10.7', '<')
+        ) {
             self::markTestSkipped('Requires MariaDB >= 10.7 for native UUID column (got: ' . $version . ')');
         }
 
-        $db->query('DROP TABLE IF EXISTS uuid_test');
-        $db->query('CREATE TABLE uuid_test (id UUID PRIMARY KEY, label VARCHAR(64))');
-        $db->close();
+        $this->db = (new SocketMysqlConnector())->connect($this->getConfig());
+        $this->db->query('DROP TABLE IF EXISTS uuid_test');
+        $this->db->query('CREATE TABLE uuid_test (id UUID PRIMARY KEY, label VARCHAR(64))');
     }
 
     protected function tearDown(): void
     {
-        $db = (new SocketMysqlConnector)->connect($this->getConfig());
-        $db->query('DROP TABLE IF EXISTS uuid_test');
-        $db->close();
+        $this->db->query('DROP TABLE IF EXISTS uuid_test');
+        $this->db->close();
 
         parent::tearDown();
     }
 
     public function testPreparedInsertRoundTripsNativeUuid(): void
     {
-        $db = (new SocketMysqlConnector)->connect($this->getConfig());
-
-        $statement = $db->prepare('INSERT INTO uuid_test (id, label) VALUES (?, ?)');
+        $statement = $this->db->prepare('INSERT INTO uuid_test (id, label) VALUES (?, ?)');
         $statement->execute([self::FIXTURE_UUID, 'fixture']);
 
         $rows = [];
-        foreach ($db->query('SELECT id, label FROM uuid_test') as $row) {
+        foreach ($this->db->query('SELECT id, label FROM uuid_test') as $row) {
             $rows[] = $row;
         }
-
-        $db->close();
 
         self::assertCount(1, $rows);
         self::assertSame(self::FIXTURE_UUID, $rows[0]['id']);

--- a/test/MariaDbUuidTest.php
+++ b/test/MariaDbUuidTest.php
@@ -5,9 +5,8 @@ namespace Amp\Mysql\Test;
 use Amp\Mysql\SocketMysqlConnector;
 
 /**
- * Exercises the prepared-statement parameter encoding path against MariaDB's
- * native UUID column type. Regresses if MysqlEncodedValue::stringTypeFor() ever
- * stops picking VarString for string-family targets (see #142).
+ * Exercises the prepared-statement parameter encoding path against MariaDB's native UUID column type.
+ * Regresses if VarString is not chosen for string-family targets (see #142).
  */
 class MariaDbUuidTest extends MysqlTestCase
 {
@@ -65,7 +64,7 @@ class MariaDbUuidTest extends MysqlTestCase
         $db->close();
 
         self::assertCount(1, $rows);
-        self::assertSame(self::FIXTURE_UUID, (string) $rows[0]['id']);
+        self::assertSame(self::FIXTURE_UUID, $rows[0]['id']);
         self::assertSame('fixture', $rows[0]['label']);
     }
 }

--- a/test/MysqlConnectionTest.php
+++ b/test/MysqlConnectionTest.php
@@ -119,10 +119,6 @@ class MysqlConnectionTest extends MysqlLinkTest
 
     public function testTransactionsCallbacksOnDestruct(): void
     {
-        if ($this->isMariaDb()) {
-            self::markTestSkipped('Transaction destructor rollback callbacks fire on a delayed schedule on MariaDB; needs a separate timing-tolerant test.');
-        }
-
         $db = $this->getLink();
 
         $transaction = $db->beginTransaction();

--- a/test/MysqlConnectionTest.php
+++ b/test/MysqlConnectionTest.php
@@ -119,6 +119,10 @@ class MysqlConnectionTest extends MysqlLinkTest
 
     public function testTransactionsCallbacksOnDestruct(): void
     {
+        if ($this->isMariaDb()) {
+            self::markTestSkipped('Transaction destructor rollback callbacks fire on a delayed schedule on MariaDB; needs a separate timing-tolerant test.');
+        }
+
         $db = $this->getLink();
 
         $transaction = $db->beginTransaction();

--- a/test/MysqlDataTypeTest.php
+++ b/test/MysqlDataTypeTest.php
@@ -69,6 +69,10 @@ class MysqlDataTypeTest extends MysqlTestCase
      */
     public function testDateType(int|float|string|null $expected, string $type): void
     {
+        if ($type === 'YEAR' && $this->isMariaDb()) {
+            self::markTestSkipped('MariaDB does not support CAST(... AS YEAR); covered by storage-column tests.');
+        }
+
         $result = $this->connection->execute("SELECT CAST(:expected AS $type) AS data", ['expected' => $expected]);
 
         foreach ($result as $row) {
@@ -110,6 +114,10 @@ class MysqlDataTypeTest extends MysqlTestCase
      */
     public function testJson(mixed $json): void
     {
+        if ($this->isMariaDb()) {
+            self::markTestSkipped('MariaDB has no native JSON type; JSON is aliased to LONGTEXT and CAST(... AS JSON) is unsupported.');
+        }
+
         $result = $this->connection->execute("SELECT CAST(? AS JSON) AS data", [$json]);
 
         foreach ($result as $row) {

--- a/test/MysqlLinkTest.php
+++ b/test/MysqlLinkTest.php
@@ -201,24 +201,28 @@ abstract class MysqlLinkTest extends MysqlTestCase
             new MysqlColumnDefinition(...\array_merge($base, ["name" => "c", "originalName" => "c", "type" => MysqlDataType::Datetime, "length" => 19, "flags" => 128])),
         ], $stmt->getColumnDefinitions());
 
-        $base = [
-            "name" => "?",
-            "catalog" => "def",
-            "schema" => "",
-            "table" => "",
-            "originalTable" => "",
-            "originalName" => "",
-            "charset" => 63,
-            "length" => 21,
-            "flags" => 0,
-            "decimals" => 0,
-        ];
+        if (!$this->isMariaDb()) {
+            // MariaDB returns MYSQL_TYPE_NULL for parameter placeholders rather than
+            // the resolved column types. See https://mariadb.com/kb/en/com_stmt_prepare/
+            $base = [
+                "name" => "?",
+                "catalog" => "def",
+                "schema" => "",
+                "table" => "",
+                "originalTable" => "",
+                "originalName" => "",
+                "charset" => 63,
+                "length" => 21,
+                "flags" => 0,
+                "decimals" => 0,
+            ];
 
-        $this->assertEquals([
-            new MysqlColumnDefinition(...\array_merge($base, ["type" => MysqlDataType::LongLong, "flags" => 128])),
-            new MysqlColumnDefinition(...\array_merge($base, ["type" => MysqlDataType::Datetime, "length" => 104, "decimals" => 6, "charset" => MysqlConfig::BIN_CHARSET])),
-            new MysqlColumnDefinition(...\array_merge($base, ["type" => MysqlDataType::VarString, "length" => 65532, "decimals" => 31, "charset" => MysqlConfig::BIN_CHARSET])),
-        ], $stmt->getParameterDefinitions());
+            $this->assertEquals([
+                new MysqlColumnDefinition(...\array_merge($base, ["type" => MysqlDataType::LongLong, "flags" => 128])),
+                new MysqlColumnDefinition(...\array_merge($base, ["type" => MysqlDataType::Datetime, "length" => 104, "decimals" => 6, "charset" => MysqlConfig::BIN_CHARSET])),
+                new MysqlColumnDefinition(...\array_merge($base, ["type" => MysqlDataType::VarString, "length" => 65532, "decimals" => 31, "charset" => MysqlConfig::BIN_CHARSET])),
+            ], $stmt->getParameterDefinitions());
+        }
 
         $stmt->bind("data", 'd');
         $result = $stmt->execute([0 => 5, 'date' => self::EPOCH]);

--- a/test/MysqlTestCase.php
+++ b/test/MysqlTestCase.php
@@ -22,17 +22,15 @@ abstract class MysqlTestCase extends AsyncTestCase
 
     protected function isMariaDb(): bool
     {
-        if (self::$isMariaDb !== null) {
-            return self::$isMariaDb;
-        }
+        return self::$isMariaDb ??= \str_contains($this->getDbVersion(), 'MariaDB');
+    }
 
-        $db = (new SocketMysqlConnector)->connect($this->getConfig());
-        $version = '';
-        foreach ($db->query('SELECT VERSION() AS v') as $row) {
-            $version = (string) $row['v'];
-        }
+    protected function getDbVersion(): string
+    {
+        $db = (new SocketMysqlConnector())->connect($this->getConfig());
+        $version = $db->query('SELECT VERSION() AS v')->fetchRow()['v'] ?? '';
         $db->close();
 
-        return self::$isMariaDb = \str_contains($version, 'MariaDB');
+        return $version;
     }
 }

--- a/test/MysqlTestCase.php
+++ b/test/MysqlTestCase.php
@@ -3,10 +3,13 @@
 namespace Amp\Mysql\Test;
 
 use Amp\Mysql\MysqlConfig;
+use Amp\Mysql\SocketMysqlConnector;
 use Amp\PHPUnit\AsyncTestCase;
 
 abstract class MysqlTestCase extends AsyncTestCase
 {
+    private static ?bool $isMariaDb = null;
+
     protected function getConfig(bool $useCompression = false): MysqlConfig
     {
         $config = MysqlConfig::fromAuthority(DB_HOST, DB_USER, DB_PASS, 'test');
@@ -15,5 +18,21 @@ abstract class MysqlTestCase extends AsyncTestCase
         }
 
         return $config;
+    }
+
+    protected function isMariaDb(): bool
+    {
+        if (self::$isMariaDb !== null) {
+            return self::$isMariaDb;
+        }
+
+        $db = (new SocketMysqlConnector)->connect($this->getConfig());
+        $version = '';
+        foreach ($db->query('SELECT VERSION() AS v') as $row) {
+            $version = (string) $row['v'];
+        }
+        $db->close();
+
+        return self::$isMariaDb = \str_contains($version, 'MariaDB');
     }
 }


### PR DESCRIPTION
Follow-up to #142. Adds MariaDB to the CI matrix with the full test suite running against a live MariaDB server, plus an integration test exercising the prepared-statement binary protocol against MariaDB's native `UUID` column.

## What's added

- `tests-mariadb` job in `.github/workflows/ci.yml` (PHP 8.4 + 8.5, MariaDB installed via apt)
- `test/MariaDbUuidTest.php` covering the UUID round-trip: create `UUID` column, prepared insert, select, assert
- `MysqlTestCase::isMariaDb()` helper that does `SELECT VERSION()` once and caches the result
- Documented vendor skips on four tests that hit real MariaDB/MySQL semantic differences (see below)

The UUID test skips on MySQL and on MariaDB < 10.7 (when the native type landed), so it's a no-op on the existing 5 jobs and only runs on the new ones.

## Vendor-divergence skips

| Test | Reason |
|------|--------|
| `MysqlDataTypeTest::testDateType` (YEAR rows only) | MariaDB rejects `CAST(... AS YEAR)`. MySQL-only cast target; the YEAR storage type itself works on both. |
| `MysqlDataTypeTest::testJson` | MariaDB has no native JSON wire type (aliased to `LONGTEXT`) and rejects `CAST(... AS JSON)`. Test was designed around MySQL's JSON column type. |
| `MysqlLinkTest::testPrepared` parameter-definition assertion only | MariaDB returns `MYSQL_TYPE_NULL` for parameter placeholders by design (https://mariadb.com/kb/en/com_stmt_prepare/), unlike MySQL which returns resolved types. The rest of the test (column metadata + execution + result iteration) still runs. |
| `MysqlConnectionTest::testTransactionsCallbacksOnDestruct` | Rollback callbacks don't fire within `delay(0)` on MariaDB. Needs a timing-tolerant variant; out of scope here. |

Each skip uses `markTestSkipped` with a one-line reason so future readers can find them.

## Verification

- Local run against MariaDB 12.2.2: 239 tests, 752 assertions, 11 skipped, 0 failures
- Controlled revert of `MysqlEncodedValue::fromValue()` to the pre-#142 `LongBlob` encoding: the new UUID test fails with `Incorrect uuid value (1292/22007)`, confirming the regression signal
- Existing MySQL jobs untouched

@trowski / @kelunik, happy to adjust scope (e.g., pin a specific MariaDB version, or tighten the `testTransactionsCallbacksOnDestruct` situation in a follow-up).