### PR TITLE
Silence PHP 8.5 chr() deprecation in encodeInt8

### DIFF
--- a/src/MysqlDataType.php
+++ b/src/MysqlDataType.php
@@ -518,7 +518,7 @@ enum MysqlDataType: int
 
     public static function encodeInt8(int $int): string
     {
-        return \chr($int);
+        return \pack("C", $int);
     }
 
     public static function encodeInt16(int $int): string


### PR DESCRIPTION
PHP 8.5 deprecates `chr()` with values outside `[0, 255]`. The warning fires from `src/MysqlDataType.php:521` because `encodeInt8` receives negative ints from `MysqlEncodedValue::fromValue()` for the `Tiny` branch (parameters in `[-128, 127]`).

The fix swaps `\chr($int)` for `\pack("C", $int)`, which produces the same byte across the full input range and isn't deprecated. It's also consistent with the existing idiom in this file:

```php
encodeInt16 → \pack("v", $int)
encodeInt24 → \substr(\pack("V", $int), 0, 3)
encodeInt32 → \pack("V", $int)
encodeInt8  → \pack("C", $int)  // this PR
```

## Verification

Bit-identical output across the full input range that `encodeInt8` actually sees (`[-128, 250]`):

```
php -r 'for ($i = -128; $i < 256; $i++) { assert(chr($i & 0xff) === pack("C", $i)); }'   // silent pass
```

A direct smoke test of the swapped function:

```
encodeInt8(-128) = 0x80
encodeInt8(  -1) = 0xff
encodeInt8(   0) = 0x00
encodeInt8( 127) = 0x7f
encodeInt8( 200) = 0xc8
encodeInt8( 255) = 0xff
```

No deprecation triggered after the change.

The other `\chr()` call sites in the codebase (`src/Internal/ConnectionProcessor.php`) all pass small non-negative values (cursor flags, bind counts, charset constants, length bytes) and don't trigger the deprecation, so they're left alone.