### PR TITLE
Await onClose callback in testTransactionsCallbacksOnDestruct

### DIFF
--- a/test/MysqlConnectionTest.php
+++ b/test/MysqlConnectionTest.php
@@ -4,10 +4,10 @@ namespace Amp\Mysql\Test;
 
 use Amp\CancelledException;
 use Amp\DeferredCancellation;
+use Amp\DeferredFuture;
 use Amp\Mysql\MysqlConnection;
 use Amp\Mysql\MysqlLink;
 use Amp\Mysql\SocketMysqlConnector;
-use function Amp\delay;
 use function Amp\Mysql\connect;
 
 class MysqlConnectionTest extends MysqlLinkTest
@@ -121,12 +121,15 @@ class MysqlConnectionTest extends MysqlLinkTest
     {
         $db = $this->getLink();
 
+        $closed = new DeferredFuture();
+
         $transaction = $db->beginTransaction();
         $transaction->onCommit($this->createCallback(0));
         $transaction->onRollback($this->createCallback(1));
         $transaction->onClose($this->createCallback(1));
+        $transaction->onClose($closed->complete(...));
 
         unset($transaction);
-        delay(0); // Destructor is async, so give control to the loop to invoke callbacks.
+        $closed->getFuture()->await();
     }
 }


### PR DESCRIPTION
Follow-up from #144.

@trowski you mentioned in #144 that `testTransactionsCallbacksOnDestruct` should be independent of the server. Digging in: the test is environment-independent in intent, but it relies on `delay(0)` being long enough for the destructor's async ROLLBACK round-trip to complete. That's a one-tick race, not a deterministic wait, and it's the reason the MariaDB job was tripping.

## Reproduction

Against MariaDB 12.2.2 via Docker on macOS:

```
1) Amp\Mysql\Test\MysqlConnectionTest::testTransactionsCallbacksOnDestruct
Expectation failed for method name is "__invoke" when invoked 1 time(s).
Method was expected to be called 1 times, actually called 0 times.
```

Against MySQL 8.4.9 via Docker on macOS the same test also fails. With instrumentation, `onRollback` and `onClose` fire 50-80 event loop ticks after `delay(0)` returns on both servers. The test passes in CI only because localhost MySQL on the GitHub Actions runner wins the race within a single tick.

So both your read and mine were right: the test is server-independent in spirit, and flaky on every server in practice. Just less visibly on the CI box.

## Fix

Replace `delay(0)` with awaiting a `DeferredFuture` completed by an `onClose` callback. No timeout, no tick counting, deterministic on either server.

## Verification

`MysqlConnectionTest`: 62/62 passing against MariaDB 12.2.2 and MySQL 8.4.9, both via Docker.

Not a hard sell. If you'd rather keep the `delay(0)` form and document this as a known-flaky case, I won't push back.